### PR TITLE
Added alias argument to allow for alias paths

### DIFF
--- a/linkPackage.js
+++ b/linkPackage.js
@@ -3,8 +3,8 @@
 var path = require("path");
 var fs = require("fs");
 
-function linkPackage(folderName) {
-    var packageName = require("../../package.json").name;
+function linkPackage(folderName, alias) {
+    var packageName = alias || require("../../package.json").name;
     var nodeModules = path.resolve(__dirname, "../");
     var dstPath = path.join(nodeModules, packageName);
     var srcPath = path.resolve(__dirname, "../../");


### PR DESCRIPTION
Thanks for sharing your method for getting non relative links. 

I wanted to share a change I made that helped me somewhat. 

With the alias argument you can do things like:

``` bash
linkPackage('app/actions','actions');
```

And then refer to them as

``` bash
var MyAction = require('actions/MyAction');
```

Just something I have found quite useful.
